### PR TITLE
Remove command-L for switching modes

### DIFF
--- a/helper/src/content.js
+++ b/helper/src/content.js
@@ -369,12 +369,11 @@ ssbContent.handleMessage = function(message, sender, respond) {
 // HANDLEHOTKEY -- handle global hot-keys
 ssbContent.handleHotKey = function(evt) {
     
-    // We're looking for Command-Shift-L in any state,
-    // and Command-L only when window is app-style
+    // We're looking for Command-Shift-L in any state
     if ((evt.keyCode == 76) &&
 	evt.metaKey &&
-	(! evt.altKey) && (! evt.ctrlKey) &&
-	((ssbContent.isMainTab == 'popup') || evt.shiftKey)) {
+	evt.shiftKey &&
+	(! evt.altKey) && (! evt.ctrlKey)) {
 	
 	chrome.runtime.sendMessage({type: 'windowSwitch'});
     } 

--- a/helper/src/manifest.json
+++ b/helper/src/manifest.json
@@ -4,7 +4,7 @@
     "name": "Epichrome Helper",
     "short_name": "EpichromHelp",
     "description": "Handles link redirection for Mac apps created with Epichrome.",
-    "version": "1.1.1",
+    "version": "1.1.2",
     
     "background": {
     	"scripts": ["shared.js", "background.js"]


### PR DESCRIPTION
Fixes issue #72, "command-L to access URL bar works inconsistently",
by removing the code to intercept command-L and switch modes if
necessary.

This means that only command-shift-L can be used to shift modes, but
the behavior will be consistent.