### PR TITLE
Fix #78 UnicodeError on utf-16 without BOM

### DIFF
--- a/app/src/strings.py
+++ b/app/src/strings.py
@@ -40,7 +40,7 @@ re_strings = re.compile(ur'((?:(CFBundleDisplayName)|(CFBundleName))\s*=\s*")[^"
 
 # go through each directory & filter
 for lprojdir in sys.argv[3:]:
-    
+
     # read in the InfoPlist.strings file, then reopen for writing
     stringsfile = lprojdir + "/InfoPlist.strings"
     try:
@@ -48,10 +48,16 @@ for lprojdir in sys.argv[3:]:
         intext = infile.read()
         infile.close()
         outfile = codecs.open(stringsfile, "w", "utf-16")
-    except:
-        print sys.exc_info()[1][1]
-        exit(2)
-    
+    except UnicodeError:
+        try:
+            infile = codecs.open(stringsfile, "r", "utf-8")
+            intext = infile.read()
+            infile.close()
+            outfile = codecs.open(stringsfile, "w", "utf-8")
+        except:
+            print sys.exc_info()
+            exit(2)
+
     # replace the dock and menubar names
     prevend = 0
     outtext = []
@@ -64,7 +70,7 @@ for lprojdir in sys.argv[3:]:
             curname = menuname
         outtext.append(m.group(1) + curname + m.group(4))
     outtext.append(intext[prevend:])
-    
+
     # write out the output file
     try:
         outfile.write(''.join(outtext))


### PR DESCRIPTION
I ran into a weird issue which took me a while to figure out. I'm pretty sure it's the same issue as #78 

Epichrome suddenly stopped working after a few months. Creating new browsers started showing:

```
Creation failed: Error filtering InfoPlist.strings (Traceback (most recent call last):
  File "/Users/vhf/Documents/My Epichrome App.app.25444/Contents.13149/Resources/Scripts/strings.py", line 52, in <module>
    print sys.exc_info()[1][1]
IndexError: tuple index out of range)
```

When changing line 52 to `print sys.exc_info()` instead of `print sys.exc_info()[1][1]`, I got:

```
Creation failed: Error filtering InfoPlist.strings ((<type 'exceptions.UnicodeError'>, UnicodeError('UTF-16 stream does not start with BOM',), <traceback object at 0x1088743b0>))
```

 Here is a fix.