### PR TITLE
Use subprocess and the "/usr/bin/open" command instead of the flawed webbrowser module

### DIFF
--- a/app/src/host-script.py
+++ b/app/src/host-script.py
@@ -24,7 +24,7 @@
 import struct
 import sys
 import json
-import webbrowser
+import subprocess
 import os
 
 
@@ -89,8 +89,8 @@ while 1:
     if 'url' in message:
         # open the url
         try:
-            webbrowser.open(message['url'])
-        except webbrowser.Error:
+            subprocess.check_call(["/usr/bin/open", message['url']])
+        except subprocess.CalledProcessError:
             send_result("error", message['url'])
         else:
             send_result("success", message['url'])


### PR DESCRIPTION
This should fix issue #114, and should also ensure that anything set as the default browser will be used, even if the `webbrowser` module doesn't support it.