### PR TITLE
changed "python" to "/usr/bin/python" in app/src/runtime.sh for consi…

### DIFF
--- a/app/src/runtime.sh
+++ b/app/src/runtime.sh
@@ -877,7 +877,7 @@ function filterchromeinfoplist {  # PY-CONTENTS-DIR DEST-CONTENTS-DIR FILTER-KEY
 	
 	# run python script to filter Info.plist
 	local pyerr=
-	try 'pyerr&=' python "$pyContentsDir/Resources/Scripts/infoplist.py" \
+	try 'pyerr&=' /usr/bin/python "$pyContentsDir/Resources/Scripts/infoplist.py" \
 	    "$chromeInfoPlist" \
 	    "$tmpInfoPlist" \
 	    "${filterkeys[@]}" 'Error filtering Info.plist file.'


### PR DESCRIPTION
changed "python" to "/usr/bin/python" in app/src/runtime.sh for consistency. Without this, when opening Epichrome apps from a terminal, whichever executable is aliased to `python` by a particular user will be used. This will cause breakage or at least inability to parse the info.plist file when `python` is aliased to a python 3 version.